### PR TITLE
chore(option): add "pysen.trace.server" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,9 @@ Controls target names for pysen to invoke in the format task.
 
 - Value: array of strings
 - Default: `["format", "lint"]`
+
+#### pysen.trace.server
+Traces the communication between VSCode and the pysen language server.
+
+- Value: string
+- Default: `"off"`

--- a/package.json
+++ b/package.json
@@ -117,6 +117,17 @@
 						"lint"
 					],
 					"description": "Controls target names for pysen to invoke in the format task."
+				},
+				"pysen.trace.server": {
+					"scope": "window",
+					"type": "string",
+					"enum": [
+						"off",
+						"messages",
+						"verbose"
+					],
+					"default": "off",
+					"description": "Traces the communication between VSCode and the pysen language server."
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,7 @@ export function activate(context: ExtensionContext) {
 	};
 
 	client = new LanguageClient(
+		'pysen',
 		'pysen language server',
 		serverOptions,
 		clientOptions


### PR DESCRIPTION
## Description

Add the `*.trace.server` setting to the configuration option, so that configuration completion also works in `settings.json`.

**Reference:**:

- <https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server>

**For example, here's an example of a configuration with another vscode extension**:

- vscode-yaml 
  - <https://github.com/redhat-developer/vscode-yaml/blob/main/package.json#L98-L107>
- VSCode's buitin-in html-language-features
  - <https://github.com/microsoft/vscode/blob/main/extensions/html-language-features/package.json#L225-L235>
- VSCode's buitin-in css-language-features
  - <https://github.com/microsoft/vscode/blob/main/extensions/css-language-features/package.json#L300-L309>

## DEMO(mp4)

https://user-images.githubusercontent.com/188642/141717210-6e336a51-ca51-44c0-a3dd-e2c0d52f30ef.mp4


